### PR TITLE
Added jwgmeligmeyling GitHub actions to upload Maven reports to PR

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -28,6 +28,18 @@ on:
         description: "Enable SSH session to the runner"
         required: false
         default: "false"
+      uploadCheckstyleReport:
+        type: string
+        description: "Enable the upload of any Checkstyle report created by Maven"
+        default: "true"
+      uploadPMDReport:
+        type: string
+        description: "Enable the upload of any PMD report created by Maven"
+        default: "true"
+      uploadSpotbugsReport:
+        type: string
+        description: "Enable the upload of any Spotbugs report created by Maven"
+        default: "true"
 
 permissions:
   # This is required for report upload
@@ -78,15 +90,18 @@ jobs:
 
     - name: Upload Checkstyle reports to GitHub
       uses: jwgmeligmeyling/checkstyle-github-action@v1.2
+      if: ${{ inputs.uploadCheckstyleReport == 'true' }}
       with:
         path: "**/checkstyle-result.xml"
 
     - name: Upload Spotbugs reports to GitHub
       uses: jwgmeligmeyling/spotbugs-github-action@v1.2
+      if: ${{ inputs.uploadSpotbugsReport == 'true' }}
       with:
         path: "**/spotbugsXml.xml"
 
     - name: Upload PMD reports to GitHub
       uses: jwgmeligmeyling/pmd-github-action@v1.2
+      if: ${{ inputs.uploadPMDReport == 'true' }}
       with:
         path: "**/pmd.xml"

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -28,7 +28,13 @@ on:
         description: "Enable SSH session to the runner"
         required: false
         default: "false"
-        
+
+permissions:
+  # This is required for report upload
+  checks: write
+  contents: write
+  pull-requests: write
+
 jobs:
   build:
 
@@ -69,3 +75,18 @@ jobs:
       
     - name: Build with Maven
       run: mvn ${{ env.debugFlag }} --batch-mode  --file pom.xml clean ${{ inputs.mavenPhases }}
+
+    - name: Upload Checkstyle reports to GitHub
+      uses: jwgmeligmeyling/checkstyle-github-action@v1.2
+      with:
+        path: "**/checkstyle-result.xml"
+
+    - name: Upload Spotbugs reports to GitHub
+      uses: jwgmeligmeyling/spotbugs-github-action@v1.2
+      with:
+        path: "**/spotbugsXml.xml"
+
+    - name: Upload PMD reports to GitHub
+      uses: jwgmeligmeyling/pmd-github-action@v1.2
+      with:
+        path: "**/pmd.xml"

--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ jobs:
   build:
     # Call this shared workflow (use `@v1` to use a specific version, instead of the latest)
     uses: sentrysoftware/workflows/.github/workflows/maven-build.yml@main
+    permissions:
+      packages: write
+      checks: write
+      contents: write
+      pull-requests: write
     with:
       jdkVersion: "17"
       nodeVersion: "20.x"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This repository provides common workflows to be [used as GitHub Actions](https:/
 
 ## Maven Build
 
-The `maven-build.yml` workflow simply builds a Maven project with the `mvn verify` goal. It's designed to be invoked on `push` on PRs, so that this action is considered as a *Check* on the PR, i.e. it will prevent the build from being merged if the build fails.
+The `maven-build.yml` workflow simply builds a Maven project with the `mvn verify site` phases. It's designed to be invoked on `push` on PRs, so that this action is considered as a *Check* on the PR, i.e. it will prevent the build from being merged if the build fails. Produced reports such as checkstyle, PMD and spotbugs will then be added as comments on pull-request.
 
 ### Inputs
 
@@ -32,6 +32,9 @@ The `maven-build.yml` workflow simply builds a Maven project with the `mvn verif
 | `nodeVersion` | Version of the NodeJS to setup for this project. **Optional** (if not specified, NodeJS won't be installed). See [supported syntax](https://github.com/actions/setup-node#supported-version-syntax). | *None* |
 | `debug` | Whether to run Maven in debug mode (with `-X` option) | `"false" |
 | `ssh` | Whether to open a SSH session in the GitHub Actions runner, to let you interact with the system that performed the build. **SSH session automatically closes after 10 minutes of inactivity.** | `"false"` |
+| `uploadCheckstyleReport` | Whether to upload any Checkstyle report created by Maven | `"true"` |
+| `uploadPMDReport` | Whether to upload any PMD report created by Maven | `"true"` |
+| `uploadSpotbugsReport` | Whether to upload any Spotbugs report created by Maven | `"true"` |
 
 ### How to use it?
 
@@ -63,21 +66,34 @@ on:
         description: Open SSH session in the runner
         required: false
         default: false
+	  uploadCheckstyleReport:
+        type: boolean
+        description: Upload Checkstyle report created by Maven
+        required: false
+        default: true
+	  uploadPMDReport:
+        type: boolean
+        description: Upload PMD report created by Maven
+        required: false
+        default: true
+	  uploadSpotbugsReport:
+        type: boolean
+        description: Upload Spotbugs report created by Maven
+        required: false
+        default: true
 
 jobs:
   build:
     # Call this shared workflow (use `@v1` to use a specific version, instead of the latest)
     uses: sentrysoftware/workflows/.github/workflows/maven-build.yml@main
-    permissions:
-      packages: write
-      checks: write
-      contents: write
-      pull-requests: write
     with:
       jdkVersion: "17"
       nodeVersion: "20.x"
       debug: ${{ github.event_name == 'workflow_dispatch' && inputs.debug }}
       ssh: ${{ github.event_name == 'workflow_dispatch' && inputs.ssh }}
+	  uploadCheckstyleReport: ${{ inputs.uploadCheckstyleReport }}
+	  uploadPMDReport: ${{ inputs.uploadPMDReport }}
+	  uploadSpotbugsReport: ${{ inputs.uploadSpotbugsReport }}
 ```
 
 ### Troubleshooting the build

--- a/README.md
+++ b/README.md
@@ -66,17 +66,17 @@ on:
         description: Open SSH session in the runner
         required: false
         default: false
-	  uploadCheckstyleReport:
+      uploadCheckstyleReport:
         type: boolean
         description: Upload Checkstyle report created by Maven
         required: false
         default: true
-	  uploadPMDReport:
+      uploadPMDReport:
         type: boolean
         description: Upload PMD report created by Maven
         required: false
         default: true
-	  uploadSpotbugsReport:
+      uploadSpotbugsReport:
         type: boolean
         description: Upload Spotbugs report created by Maven
         required: false
@@ -91,9 +91,9 @@ jobs:
       nodeVersion: "20.x"
       debug: ${{ github.event_name == 'workflow_dispatch' && inputs.debug }}
       ssh: ${{ github.event_name == 'workflow_dispatch' && inputs.ssh }}
-	  uploadCheckstyleReport: ${{ inputs.uploadCheckstyleReport }}
-	  uploadPMDReport: ${{ inputs.uploadPMDReport }}
-	  uploadSpotbugsReport: ${{ inputs.uploadSpotbugsReport }}
+      uploadCheckstyleReport: ${{ inputs.uploadCheckstyleReport }}
+      uploadPMDReport: ${{ inputs.uploadPMDReport }}
+      uploadSpotbugsReport: ${{ inputs.uploadSpotbugsReport }}
 ```
 
 ### Troubleshooting the build


### PR DESCRIPTION
Added `jwgmeligmeyling`'s actions to the workflow.

The actions seems obsolete as they are not maintained since 2020 and depends on Node.js 16. But they still works if the projects declare the right permissions.

The `README.md` has been updated accordingly to declare the permissions required to properly run the workflow.