### PR TITLE
 Upload artifacts built with the GitHub Action in maven-build.yml

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -88,6 +88,9 @@ jobs:
     - name: Build with Maven
       run: mvn ${{ env.debugFlag }} --batch-mode  --file pom.xml clean ${{ inputs.mavenPhases }}
 
+    - name: Attach Maven artifacts to the build
+      uses: sentrysoftware/upload-buildinfo-outputs@v1
+
     - name: Upload Checkstyle reports to GitHub
       uses: jwgmeligmeyling/checkstyle-github-action@v1.2
       if: ${{ inputs.uploadCheckstyleReport == 'true' }}


### PR DESCRIPTION
Added custom action upload-buildinfo-outputs released last week.
[Issue #21](https://github.com/sentrysoftware/workflows/issues/21)