### PR TITLE
Update maven-central-release.yml to remove old Nexus staging repo details

### DIFF
--- a/.github/workflows/maven-central-release.yml
+++ b/.github/workflows/maven-central-release.yml
@@ -184,23 +184,6 @@ jobs:
           ./target/release/target/*.jar
           ./target/release/target/*.buildinfo
 
-    - name: Summary with staging repositories and buildinfo
-      id: stagingList
-      run: |
-        echo "# Staging Repositories" >> $GITHUB_STEP_SUMMARY
-        echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-        mvn -B -U \
-          -Prelease \
-          org.sonatype.plugins:nexus-staging-maven-plugin:rc-list >> $GITHUB_STEP_SUMMARY
-        echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-        echo "# Buildinfo" >> $GITHUB_STEP_SUMMARY
-        echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-        cat target/*.buildinfo >> $GITHUB_STEP_SUMMARY
-        echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-      env:
-        MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-        MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
-
     - name: Create Pull Request from ${{ needs.release.outputs.branchName }} to ${{ github.event.repository.default_branch }}
       uses: devops-infra/action-pull-request@v0.6.0
       with:


### PR DESCRIPTION
In the release workflow, we simply remove the step that was getting detailed information about the staging repository where the artifacts had been pushed, using the nexus staging plugin.

Now that everything is managed with the new Maven Central "deployments" feature, there is no need for this step.